### PR TITLE
Fix for matching 0 in int conversion.

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -286,7 +286,7 @@ def int_convert(base):
         else:
             sign = 1
 
-        if string[0] == '0':
+        if string[0] == '0' and len(string) > 1:
             if string[1] in 'bB':
                 base = 2
             elif string[1] in 'oO':

--- a/test_parse.py
+++ b/test_parse.py
@@ -224,6 +224,7 @@ class TestParse(unittest.TestCase):
         def n(fmt, s, e):
             if parse.parse(fmt, s) is not None:
                 self.fail('%r matched %r' % (fmt, s))
+        y('a {:d} b', 'a 0 b', 0)
         y('a {:d} b', 'a 12 b', 12)
         y('a {:5d} b', 'a    12 b', 12)
         y('a {:5d} b', 'a   -12 b', -12)


### PR DESCRIPTION
First, great library!  I've really enjoyed using it while playing with `behave`.

Pull request is just a very simple fix:  The fancy base handling causes integer conversions matching 0 to raise an `IndexError`.  I've also added a test to make sure it doesn't come back.

Thanks,

James
