### PR TITLE
Added precision delimiter on strings

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -922,6 +922,8 @@ class Parser(object):
 
         elif type:
             s = r'\%s+' % type
+        elif 'precision' in format:
+            s = '.{%s}' % format['precision']
         else:
             s = '.+?'
 


### PR DESCRIPTION
Add basic precision support for strings. Usually I write a formatter using the sample rule {value:X<20.20} so if the user inputs something bigger than 20 chars it automatically trims the string. This patch enables this on parse.