### PR TITLE
Fix test_too_many_fields with Python 3.5

### DIFF
--- a/test_parse.py
+++ b/test_parse.py
@@ -6,6 +6,7 @@ See the end of the source file for the license of use.
 
 import unittest
 from datetime import datetime, time
+import re
 
 import parse
 
@@ -624,8 +625,13 @@ class TestParse(unittest.TestCase):
         self.assertEqual(r.fixed[21], 'spam')
 
     def test_too_many_fields(self):
-        p = parse.compile('{:ti}' * 15)
-        self.assertRaises(parse.TooManyFields, p.parse, '')
+        # Python 3.5 removed the limit of 100 named groups in a regular expression,
+        # so only test for the exception if the limit exists.
+        try:
+            re.compile("".join("(?P<n{n}>{n}-)".format(n=i) for i in range(101)))
+        except AssertionError:
+            p = parse.compile('{:ti}' * 15)
+            self.assertRaises(parse.TooManyFields, p.parse, '')
 
 
 class TestSearch(unittest.TestCase):


### PR DESCRIPTION
Python versions before 3.5 had a limit of 100 groups in regular
expressions. This limit was removed during 3.5 development:

http://bugs.python.org/issue22437
https://hg.python.org/cpython/rev/0b85ea4bd1af

The test_too_many_fields test asserts that the limit exists by
attempting to parse a string with 15 fields, which triggers the 100
named groups limit.

Adjust the test so that if first checks to see whether the limit of 100
named groups exists, and only assert that parsing 15 fields fails if
that is the case.
