### PR TITLE
Clarify error message on invalid format spec

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -609,7 +609,7 @@ def extract_format(format, extra_types):
     # the rest is the type, if present
     type = format
     if type and type not in ALLOWED_TYPES and type not in extra_types:
-        raise ValueError('type %r not recognised' % type)
+        raise ValueError('format spec %r not recognised' % type)
 
     return locals()
 


### PR DESCRIPTION
The error message I got this morning was a little bit cryptic:

>>> ValueError: type ' 5>d' not recognised

I suggest changing it to be a little clearer. "type not recognized" seems to be saying that "d" isn't a valid type. However the problem in my case was just that I had inadvertently swapped two characters (the correct format spec is " >5d").