### PR TITLE
Add check that part is fully enclosed in matching braces before handling

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -885,7 +885,7 @@ class Parser(object):
                 e.append(r'\{')
             elif part == '}}':
                 e.append(r'\}')
-            elif part[0] == '{':
+            elif part[0] == '{' and part[-1] == '}':
                 # this will be a braces-delimited field to handle
                 e.append(self._handle_field(part))
             else:


### PR DESCRIPTION
This checks that the field is enclosed in matching braces before handling, fixing a bug where certain patterns can lead to an incorrect match even when there's no closing brace.

Fixes #79 