### PR TITLE
FIX #121: inv_convert memory-effect

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -537,23 +537,25 @@ class int_convert:
             number_start = 0
 
         # If base wasn't specified, detect it automatically
-        if self.base is None:
-
+        base = self.base
+        if base is None:
+            # -- AVOID MEMORY-EFFECT:
+            # If base is unspecified, it must be discovered every time.
             # Assume decimal number, unless different base is detected
-            self.base = 10
+            base = 10
 
             # For number formats starting with 0b, 0o, 0x, use corresponding base ...
             if string[number_start] == '0' and len(string) - number_start > 2:
                 if string[number_start + 1] in 'bB':
-                    self.base = 2
+                    base = 2
                 elif string[number_start + 1] in 'oO':
-                    self.base = 8
+                    base = 8
                 elif string[number_start + 1] in 'xX':
-                    self.base = 16
+                    base = 16
 
-        chars = int_convert.CHARS[: self.base]
+        chars = int_convert.CHARS[:base]
         string = re.sub('[^%s]' % chars, '', string.lower())
-        return sign * int(string, self.base)
+        return sign * int(string, base)
 
 
 class convert_first:

--- a/test_parse.py
+++ b/test_parse.py
@@ -414,6 +414,14 @@ class TestParse(unittest.TestCase):
         y('a {:b} b', 'a +1010 b', 10)
         y('a {:x} b', 'a +1010 b', 0x1010)
 
+    def test_parse_number_twice(self):
+        """Verifies that memory-effect does not occur (issue #121)."""
+        parser = parse.Parser("{:d}")
+        result1 = parser.parse("0x12")
+        self.assertEqual(result1.fixed[0], 18)
+        result2 = parser.parse("12")
+        self.assertEqual(result2.fixed[0], 12)
+
     def test_two_datetimes(self):
         r = parse.parse('a {:ti} {:ti} b', 'a 1997-07-16 2012-08-01 b')
         self.assertEqual(len(r.fixed), 2)


### PR DESCRIPTION
Fixes the memory-effect in the int_convert class if number-base
is unspecified. In this case, the number base must be rediscovered
each time. Otherwise, the first number-base is reused with
unexpected effects.

* [x]  Fixes the issue in the class.
* [x]  Provides a test that verifies that the issue is solved.