### PR TITLE
Support slice access to results

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1272,7 +1272,7 @@ class Result(object):
         self.spans = spans
 
     def __getitem__(self, item):
-        if isinstance(item, int):
+        if isinstance(item, (int, slice)):
             return self.fixed[item]
         return self.named[item]
 

--- a/test_parse.py
+++ b/test_parse.py
@@ -105,6 +105,14 @@ class TestResult(unittest.TestCase):
         self.assertRaises(IndexError, r.__getitem__, 2)
         self.assertRaises(KeyError, r.__getitem__, 'spam')
 
+    def test_slice_access(self):
+        r = parse.Result((1, 2, 3, 4), {}, None)
+        self.assertEqual(r[1:3], (2, 3))
+        self.assertEqual(r[-5:5], (1, 2, 3, 4))
+        self.assertEqual(r[:4:2], (1, 3))
+        self.assertEqual(r[::-2], (4, 2))
+        self.assertEqual(r[5:10], tuple())
+
     def test_named_access(self):
         r = parse.Result((), {'spam': 'ham'}, None)
         self.assertEqual(r['spam'], 'ham')


### PR DESCRIPTION
Makes it slightly more ergonomic to access a subset of the results when there are many items.

```
>>> result = parse("({:d}, {:d}, {:d}) -> ({:d}, {:d}, {:d})",  "(1, 2, 3) -> (4, 5, 6)")
>>> start, stop = result[:3], result[3:]
>>> start
(1, 2, 3)
>>> stop
(4, 5, 6)
```