### PR TITLE
Fix handling of unused alignment

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1261,11 +1261,11 @@ class Parser(object):
 
         # align "=" has been handled
         if align == '<':
-            s = '%s%s+' % (s, fill)
+            s = '%s%s*' % (s, fill)
         elif align == '>':
             s = '%s*%s' % (fill, s)
         elif align == '^':
-            s = '%s*%s%s+' % (fill, s, fill)
+            s = '%s*%s%s*' % (fill, s, fill)
 
         return s
 

--- a/test_parse.py
+++ b/test_parse.py
@@ -871,6 +871,11 @@ class TestBugs(unittest.TestCase):
         r = parse.search("{:^2S}", "foo")
         self.assertEqual(r[0], "foo")
 
+        # specifically test for the case in issue #118 as well
+        r = parse.parse("Column {:d}:{:^}", "Column 1: Timestep")
+        self.assertEqual(r[0], 1)
+        self.assertEqual(r[1], "Timestep")
+
     def test_unused_left_alignment_bug(self):
         r = parse.parse("{:<2S}", "foo")
         self.assertEqual(r[0], "foo")

--- a/test_parse.py
+++ b/test_parse.py
@@ -865,17 +865,17 @@ class TestBugs(unittest.TestCase):
         # prior to the fix, this would raise an AttributeError
         pickle.dumps(p)
 
-    def test_search_centered_bug_112(self):
-        r = parse.parse("{:^},{:^}", " 12 , 34 ")
-        self.assertEqual(r[1], "34")
-        r = parse.search("{:^},{:^}", " 12 , 34 ")
-        self.assertEqual(r[1], "34")
+    def test_unused_centered_alignment_bug(self):
+        r = parse.parse("{:^2S}", "foo")
+        self.assertEqual(r[0], "foo")
+        r = parse.search("{:^2S}", "foo")
+        self.assertEqual(r[0], "foo")
 
-    def test_search_left_align_bug_112(self):
-        r = parse.parse("{:<},{:<}", "12 ,34 ")
-        self.assertEqual(r[1], "34")
-        r = parse.search("{:<},{:<}", "12 ,34 ")
-        self.assertEqual(r[1], "34")
+    def test_unused_left_alignment_bug(self):
+        r = parse.parse("{:<2S}", "foo")
+        self.assertEqual(r[0], "foo")
+        r = parse.search("{:<2S}", "foo")
+        self.assertEqual(r[0], "foo")
 
     def test_match_trailing_newline(self):
         r = parse.parse('{}', 'test\n')


### PR DESCRIPTION
This reverts a change introduced in 55467d28 (1.17) in order to resolve #112, but which broke more verbose use cases.

The proper solution to #112 should have been to instructing the user to use the '{:^S},{^:S}' pattern instead, because in some cases format() is not really reversible so you ought to be more verbose in your format.

This resolves #118.