### PR TITLE
Add support for sign specifiers in number formats.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ format specification might have been used.
 
 Most of `format()`'s `Format Specification Mini-Language`_ is supported:
 
-   [[fill]align][0][width][.precision][type]
+   [[fill]align][sign][0][width][.precision][type]
 
 The differences between `parse()` and `format()` are:
 
@@ -143,7 +143,8 @@ The differences between `parse()` and `format()` are:
   That is, the "#" format character is handled automatically by d, b, o
   and x formats. For "d" any will be accepted, but for the others the correct
   prefix must be present if at all.
-- Numeric sign is handled automatically.
+- Numeric sign is handled automatically.  A sign specifier can be given, but
+  has no effect.
 - The thousands separator is handled automatically if the "n" type is used.
 - The types supported are a slightly different mix to the format() types.  Some
   format() types come directly over: "d", "n", "%", "f", "e", "b", "o" and "x".

--- a/parse.py
+++ b/parse.py
@@ -758,7 +758,7 @@ ALLOWED_TYPES = set(list('nbox%fFegwWdDsSl') + ['t' + c for c in 'ieahgcts'])
 
 
 def extract_format(format, extra_types):
-    """Pull apart the format [[fill]align][0][width][.precision][type]"""
+    """Pull apart the format [[fill]align][sign][0][width][.precision][type]"""
     fill = align = None
     if format[0] in '<>=^':
         align = format[0]
@@ -767,6 +767,9 @@ def extract_format(format, extra_types):
         fill = format[0]
         align = format[1]
         format = format[2:]
+
+    if format.startswith(('+', '-', ' ')):
+        format = format[1:]
 
     zero = False
     if format and format[0] == '0':

--- a/test_parse.py
+++ b/test_parse.py
@@ -205,6 +205,17 @@ class TestParse(unittest.TestCase):
         r = parse.parse('hello {:w} {:w}', 'hello 12 people')
         self.assertEqual(r.fixed, ('12', 'people'))
 
+    def test_sign(self):
+        # sign is ignored
+        r = parse.parse('Pi = {:.7f}', 'Pi = 3.1415926')
+        self.assertEqual(r.fixed, (3.1415926,))
+        r = parse.parse('Pi = {:+.7f}', 'Pi = 3.1415926')
+        self.assertEqual(r.fixed, (3.1415926,))
+        r = parse.parse('Pi = {:-.7f}', 'Pi = 3.1415926')
+        self.assertEqual(r.fixed, (3.1415926,))
+        r = parse.parse('Pi = {: .7f}', 'Pi = 3.1415926')
+        self.assertEqual(r.fixed, (3.1415926,))
+
     def test_precision(self):
         # pull a float out of a string
         r = parse.parse('Pi = {:.7f}', 'Pi = 3.1415926')


### PR DESCRIPTION
Closes https://github.com/r1chardj0n3s/parse/issues/88.