### PR TITLE
readme: Clarify 'd' type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ w     Letters, numbers and underscore             str
 W     Not letters, numbers and underscore         str
 s     Whitespace                                  str
 S     Non-whitespace                              str
-d     Digits (effectively integer numbers)        int
+d     Integer numbers (optional sign, digits)     int
 D     Non-digit                                   str
 n     Numbers with thousands separators (, or .)  int
 %     Percentage (converted to value/100.0)       float


### PR DESCRIPTION
In  my understanding of the word "digits" the signs + or - would not be matched. That is indeed not the case, you can prefix your numbers with + (optional) or - and it gets matched and converted as one would expect it.

Feel free to treat this as an issue report and reword it in a different way, this is just my attempt to make it more clear.

Thanks for the cool library! :heart: 