### PR TITLE
Support matching empty strings for str-types

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -681,7 +681,7 @@ class Parser(object):
         # simplest case: no type specifier ({} or {name})
         if not format:
             self._group_index += 1
-            return wrap % r".+?"
+            return wrap % r".*?"
 
         # decode the format specification
         format = extract_format(format, self._extra_types)
@@ -692,7 +692,7 @@ class Parser(object):
         conv = self._type_conversions
         if type in self._extra_types:
             type_converter = self._extra_types[type]
-            s = getattr(type_converter, "pattern", r".+?")
+            s = getattr(type_converter, "pattern", r".*?")
             regex_group_count = getattr(type_converter, "regex_group_count", 0)
             if regex_group_count is None:
                 regex_group_count = 0
@@ -795,18 +795,18 @@ class Parser(object):
             conv[group] = partial(date_convert, mm=n + 1, dd=n + 3, hms=n + 5)
             self._group_index += 5
         elif type == "l":
-            s = r"[A-Za-z]+"
+            s = r"[A-Za-z]*"
         elif type:
-            s = r"\%s+" % type
+            s = r"\%s*" % type
         elif format.get("precision"):
             if format.get("width"):
                 s = r".{%s,%s}?" % (format["width"], format["precision"])
             else:
-                s = r".{1,%s}?" % format["precision"]
+                s = r".{0,%s}?" % format["precision"]
         elif format.get("width"):
             s = r".{%s,}?" % format["width"]
         else:
-            s = r".+?"
+            s = r".*?"
 
         align = format["align"]
         fill = format["fill"]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -741,7 +741,7 @@ def test_too_many_fields():
 
 def test_letters():
     res = parse.parse("{:l}", "")
-    assert res is None
+    assert res.fixed == ("",)
     res = parse.parse("{:l}", "sPaM")
     assert res.fixed == ("sPaM",)
     res = parse.parse("{:l}", "sP4M")

--- a/tests/test_parsetype.py
+++ b/tests/test_parsetype.py
@@ -203,7 +203,7 @@ def test_width_multi_int():
 
 def test_width_empty_input():
     res = parse.parse("{:.2}", "")
-    assert res is None
+    assert res.fixed == ("",)
     res = parse.parse("{:2}", "l")
     assert res is None
     res = parse.parse("{:2d}", "")

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -14,31 +14,31 @@ def test_braces():
 
 def test_fixed():
     # pull a simple string out of another string
-    _test_expression("{}", r"(.+?)")
-    _test_expression("{} {}", r"(.+?) (.+?)")
+    _test_expression("{}", r"(.*?)")
+    _test_expression("{} {}", r"(.*?) (.*?)")
 
 
 def test_named():
     # pull a named string out of another string
-    _test_expression("{name}", r"(?P<name>.+?)")
-    _test_expression("{name} {other}", r"(?P<name>.+?) (?P<other>.+?)")
+    _test_expression("{name}", r"(?P<name>.*?)")
+    _test_expression("{name} {other}", r"(?P<name>.*?) (?P<other>.*?)")
 
 
 def test_named_typed():
     # pull a named string out of another string
-    _test_expression("{name:w}", r"(?P<name>\w+)")
-    _test_expression("{name:w} {other:w}", r"(?P<name>\w+) (?P<other>\w+)")
+    _test_expression("{name:w}", r"(?P<name>\w*)")
+    _test_expression("{name:w} {other:w}", r"(?P<name>\w*) (?P<other>\w*)")
 
 
 def test_numbered():
-    _test_expression("{0}", r"(.+?)")
-    _test_expression("{0} {1}", r"(.+?) (.+?)")
+    _test_expression("{0}", r"(.*?)")
+    _test_expression("{0} {1}", r"(.*?) (.*?)")
     _test_expression("{0:f} {1:f}", r"([-+ ]?\d*\.\d+) ([-+ ]?\d*\.\d+)")
 
 
 def test_bird():
     # skip some trailing whitespace
-    _test_expression("{:>}", r" *(.+?)")
+    _test_expression("{:>}", r" *(.*?)")
 
 
 def test_format_variety():


### PR DESCRIPTION
This will close #138, and since there wasn't much discussion there I understand if this feature is ultimately not desired, but I thought I'd have a go at fixing it anyway. 

When matching a format that will return a `str` (i.e. format specifiers `l,w,W,s,S,D` or no format specifier), it seems valid that an empty string `""` can be matched. The same doesn't seem true for other formats, as they have no "empty" equivalent (other than None, which is already returned in these cases). 

This also fits the (inverse) behaviour of `.format()`, which allows empty strings to be passed into the arguments an subsequently formatted. 
```python
name = ""
text = "Hello {}!".format(name)  # 'Hello !'
parse("Hello {}!", text)  # Previously returned None, now returns <Result ('',) {}>
```

I've run & updated the relevant tests, but I apologise in advance if I've missed anything!