### PR TITLE
Parse zero-precision floats formatted without a decimal point

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -727,10 +727,11 @@ class Parser(object):
             self._group_index += 1
             conv[group] = percentage
         elif type == "f":
-            s = r"\d*\.\d+"
+            # precision 0 formats without a decimal point (e.g. format(20.0, ".0f") == "20")
+            s = r"\d+" if format.get("precision") == "0" else r"\d*\.\d+"
             conv[group] = convert_first(float)
         elif type == "F":
-            s = r"\d*\.\d+"
+            s = r"\d+" if format.get("precision") == "0" else r"\d*\.\d+"
             conv[group] = convert_first(Decimal)
         elif type == "e":
             s = r"\d*\.\d+[eE][-+]?\d+|nan|NAN|[-+]?inf|[-+]?INF"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -278,6 +278,11 @@ def test_numbers():
     y("a {:f} b", "a -.121 b", -0.121)
     n("a {:f} b", "a 12 b", None)
 
+    # precision 0 formats without a decimal point, so parse must accept it (issue #159)
+    y("a {:.0f} b", "a 12 b", 12.0)
+    y("foo_{:02.0f}t", "foo_20t", 20.0)
+    n("a {:.0f} b", "a 12.0 b", None)
+
     y("a {:e} b", "a 1.0e10 b", 1.0e10)
     y("a {:e} b", "a .0e10 b", 0.0e10)
     y("a {:e} b", "a 1.0E10 b", 1.0e10)


### PR DESCRIPTION
Fixes #159.

`parse` should be the inverse of `format`, but the `f`/`F` regex requires a decimal point and a fractional digit (`\d*\.\d+`). A zero-precision float formats without one, so the round-trip fails:

```python
>>> format(20.0, ".0f")
'20'
>>> parse.parse("{:.0f}", "20")   # returns None before this change
```

When the precision is explicitly 0, the pattern now matches a bare integer (`\d+`) and converts via `float`/`Decimal`. Plain `{:f}` still rejects integers with no decimal point, so the existing strictness is unchanged.

Added regression cases to `test_numbers`.