### PR TITLE
Strip alignment padding when an explicit width is given

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -809,11 +809,17 @@ class Parser(object):
         elif type:
             s = r"\%s+" % type
         elif format.get("precision"):
-            if format.get("width"):
+            # An explicit alignment means the width is only a strip hint (the
+            # fill/align handling below removes the padding), not a content
+            # minimum - so don't bake it into the capture group. Doing so would
+            # swallow the padding (e.g. "{:>10}") and, when width > precision,
+            # produce an impossible ".{width,precision}" range that fails to
+            # compile (e.g. "{:>10.4}").
+            if format.get("width") and not format.get("align"):
                 s = r".{%s,%s}?" % (format["width"], format["precision"])
             else:
                 s = r".{1,%s}?" % format["precision"]
-        elif format.get("width"):
+        elif format.get("width") and not format.get("align"):
             s = r".{%s,}?" % format["width"]
         else:
             s = r".+?"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -200,6 +200,25 @@ def test_named_aligned_typed():
     assert r.named == {"number": 12, "things": "people"}
 
 
+def test_aligned_with_width_strips_padding():
+    # An explicit alignment strips the fill padding even when a width is
+    # given: the width is only a strip hint, not a content minimum (README).
+    # parse should invert the padding produced by format().
+    for spec in (">10", "<10", "^12", "_>10", "*<11", "x^12"):
+        padded = format("hi", spec)
+        assert parse.parse("{:" + spec + "}", padded).fixed[0] == "hi", spec
+    # width with no explicit alignment keeps the fixed-width behaviour
+    assert parse.parse("{:4}", "ab  ").fixed[0] == "ab  "
+
+
+def test_aligned_with_width_and_precision():
+    # width > precision with an explicit alignment must not build an
+    # impossible ".{width,precision}" regex range (which fails to compile).
+    for spec in (">10.4", "<10.4", "^11.4", "_>10.4"):
+        padded = format("spam", spec)
+        assert parse.parse("{:" + spec + "}", padded).fixed[0] == "spam", spec
+
+
 def test_multiline():
     r = parse.parse("hello\n{}\nworld", "hello\nthere\nworld")
     assert r.fixed[0] == "there"


### PR DESCRIPTION
## Summary

`parse()` fails to strip alignment padding when a width is also specified, contradicting its own documented contract. There are two manifestations of one root cause:

**(A) Silent wrong result** — padding is returned instead of stripped:

```python
>>> import parse
>>> parse.parse("{:>10}", "        hi")[0]
'        hi'      # expected 'hi'
```

The README states: *"The align operators will cause spaces (or specified fill character) to be stripped from the parsed value. The width is not enforced; it just indicates there may be whitespace or '0's to strip."* This affects `<`, `>`, `^` and custom fills (`{:_>10}`, `{:*^12}`, …).

**(B) Leaked error** — `width > precision` with an explicit alignment crashes:

```python
>>> parse.parse("{:>10.4}", "      spam")[0]
# raises (impossible regex range ".{10,4}"), instead of returning 'spam'
```

`format("spam", ">10.4")` legitimately produces `"      spam"`, so `parse` should round-trip it.

## Cause

In `_handle_field` the width is compiled into the inner capture group as a *minimum* quantifier — `".{width,}?"` (and `".{width,precision}?"` when a precision is present). That minimum forces the capture group to consume the padding that the fill/align stripping logic (further down the same method) is supposed to remove. When `width > precision`, `".{width,precision}"` is also an impossible range that fails to compile.

The flawed assumption is that width denotes a *content* minimum. With an explicit alignment it denotes the *padded total* width — i.e. a strip hint, not a content constraint.

## Fix

Gate the two width branches on the absence of an explicit alignment. When an alignment is present, the inner group falls through to `.+?` / `.{1,precision}?` and the existing fill/align logic strips the padding. The fixed-width-field feature (a width with **no** explicit alignment, e.g. `{:4}` or `{:2}{:2}`) is left untouched.

## Verification

- Two regression tests that tie `parse` to the documented contract by inverting `format()`'s own padding across `<`/`>`/`^`, custom fills, and width+precision combinations. They fail on the current code (`AssertionError` for A, the leaked error for B) and pass with the fix.
- Full suite (including the README doctests): **101 passed, 1 skipped**, no pre-existing failures, coverage unchanged.
- A differential sweep over fill/align/width/precision combinations confirms the only remaining mismatches are the no-explicit-align fixed-width cases, which are deliberately out of scope and already covered by `test_width_str`/`test_width_constraints`.
- `ruff check` clean.

This pull request was prepared with the assistance of AI, under my direction and review.
