### PR TITLE
Support uppercase E, G and X format type specifiers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,10 +184,13 @@ f     Fixed-point numbers                         float
 F     Decimal numbers                             Decimal
 e     Floating-point numbers with exponent        float
       e.g. 1.1e-10, NAN (all case insensitive)
+E     Same as e                                   float
 g     General number format (either d, f or e)    float
+G     Same as g                                   float
 b     Binary numbers                              int
 o     Octal numbers                               int
 x     Hexadecimal numbers (lower and upper case)  int
+X     Same as x                                   int
 ti    ISO 8601 format date/time                   datetime
       e.g. 1972-01-20T10:21:36Z ("T" and "Z"
       optional)

--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -345,7 +345,7 @@ class RepeatedNameError(ValueError):
 REGEX_SAFETY = re.compile(r"([?\\.[\]()*+^$!|])")
 
 # allowed field types
-ALLOWED_TYPES = set(list("nbox%fFegwWdDsSl") + ["t" + c for c in "ieahgcts"])
+ALLOWED_TYPES = set(list("nboxX%fFeEgGwWdDsSl") + ["t" + c for c in "ieahgcts"])
 
 
 def extract_format(format, extra_types):
@@ -696,7 +696,7 @@ class Parser(object):
 
         # figure type conversions, if any
         type = format["type"]
-        is_numeric = type and type in "n%fegdobx"
+        is_numeric = type and type in "n%fegdobxEGX"
         conv = self._type_conversions
         if type in self._extra_types:
             type_converter = self._extra_types[type]
@@ -718,7 +718,7 @@ class Parser(object):
             s = r"(0[oO])?[0-7]+"
             conv[group] = int_convert(8)
             self._group_index += 1
-        elif type == "x":
+        elif type in ("x", "X"):
             s = r"(0[xX])?[0-9a-fA-F]+"
             conv[group] = int_convert(16)
             self._group_index += 1
@@ -733,10 +733,10 @@ class Parser(object):
         elif type == "F":
             s = r"\d+" if format.get("precision") == "0" else r"\d*\.\d+"
             conv[group] = convert_first(Decimal)
-        elif type == "e":
+        elif type in ("e", "E"):
             s = r"\d*\.\d+[eE][-+]?\d+|nan|NAN|[-+]?inf|[-+]?INF"
             conv[group] = convert_first(float)
-        elif type == "g":
+        elif type in ("g", "G"):
             s = r"\d+(\.\d+)?([eE][-+]?\d+)?|nan|NAN|[-+]?inf|[-+]?INF"
             self._group_index += 2
             conv[group] = convert_first(float)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -299,10 +299,22 @@ def test_numbers():
     y("a {:e} b", "a +INF b", float("inf"))
     y("a {:e} b", "a -INF b", float("-inf"))
 
+    # uppercase E/G/X behave like their lowercase counterparts, so that the
+    # output of str.format() round-trips back through parse (issue #137)
+    y("a {:E} b", "a 1.0E10 b", 1.0e10)
+    y("a {:E} b", "a 1.0e10 b", 1.0e10)
+    y("a {:E} b", "a 1.10000E10 b", 1.1e10)
+    y("a {:E} b", "a 1.0E-10 b", 1.0e-10)
+    y("a {:E} b", "a -1.0E10 b", -1.0e10)
+    y("a {:E} b", "a INF b", float("inf"))
+
     y("a {:g} b", "a 1 b", 1)
     y("a {:g} b", "a 1e10 b", 1e10)
     y("a {:g} b", "a 1.0e10 b", 1.0e10)
     y("a {:g} b", "a 1.0E10 b", 1.0e10)
+    y("a {:G} b", "a 1 b", 1)
+    y("a {:G} b", "a 1E10 b", 1e10)
+    y("a {:G} b", "a 1.0E10 b", 1.0e10)
 
     y("a {:b} b", "a 1000 b", 8)
     y("a {:b} b", "a 0b1000 b", 8)
@@ -312,6 +324,9 @@ def test_numbers():
     y("a {:x} b", "a 1234567890ABCDEF b", 0x1234567890ABCDEF)
     y("a {:x} b", "a 0x1234567890abcdef b", 0x1234567890ABCDEF)
     y("a {:x} b", "a 0x1234567890ABCDEF b", 0x1234567890ABCDEF)
+    y("a {:X} b", "a 1234567890ABCDEF b", 0x1234567890ABCDEF)
+    y("a {:X} b", "a 1234567890abcdef b", 0x1234567890ABCDEF)
+    y("a {:X} b", "a 0X1234567890ABCDEF b", 0x1234567890ABCDEF)
 
     y("a {:05d} b", "a 00001 b", 1)
     y("a {:05d} b", "a -00001 b", -1)


### PR DESCRIPTION
## Summary

`str.format()` produces uppercase **`E`**, **`G`** and **`X`** for the scientific, general and hexadecimal presentation types, but `parse()` rejected those type letters outright:

```python
>>> import parse
>>> parse.parse("{:X}", format(255, "X"))      # "FF"
ValueError: format spec 'X' not recognised
>>> parse.parse("{:E}", format(1234.5, "E"))   # "1.234500E+03"
ValueError: format spec 'E' not recognised
>>> parse.parse("{:G}", format(1234567.0, "G"))  # "1.23457E+06"
ValueError: format spec 'G' not recognised
```

So the output of `str.format()` with these (perfectly standard) specifiers could not be parsed back, even though `parse` already supports the lowercase `e`, `g` and `x`.

## Fix

The regexes for `e`/`g` already match an uppercase `E` exponent (`[eE]`), and the `x` regex already matches uppercase hex digits (`[0-9a-fA-F]`) — the only thing missing was *recognising* the uppercase type letter. This change registers `E`, `G` and `X` and dispatches them to the same handlers as `e`, `g` and `x`:

```python
>>> parse.parse("{:X}", "FF")
<Result (255,) {}>
>>> parse.parse("{:E}", "-1.234500E+03")
<Result (-1234.5,) {}>
>>> parse.parse("color #{code:X}", "color #1A2B3C")
<Result () {'code': 1715004}>
```

Behaviour is identical to the lowercase forms (including signs, `nan`/`inf`, and the `0x` prefix). `F` is left untouched, since `parse` already uses it for `Decimal`.

Closes #137.

## Changes
- `parse/__init__.py`: add `E`, `G`, `X` to `ALLOWED_TYPES` and `is_numeric`, and broaden the `e`/`g`/`x` dispatch branches to accept the uppercase variants.
- `tests/test_parse.py`: add round-trip cases for `{:E}`, `{:G}` and `{:X}` in `test_numbers`.
- `README.rst`: document the three specifiers in the format-type table.

## Testing
`pytest` — all tests pass (97 passed, 1 skipped).