### PR TITLE
fix: support explicit string format type (':s') in parse

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -696,6 +696,10 @@ class Parser(object):
 
         # figure type conversions, if any
         type = format["type"]
+        if type == "s":
+            # explicit string type specifier ('{name:s}') — treat as no type
+            # so the default pattern handling applies
+            type = ""
         is_numeric = type and type in "n%fegdobxEGX"
         conv = self._type_conversions
         if type in self._extra_types:


### PR DESCRIPTION
Fixes #116

When a format string uses the explicit `:s` type specifier (e.g. `{name:s}`), Parse's `_handle_field` method doesn't handle it. The `"s"` type falls through to the generic `elif type:` branch at line 809, which interprets `"s"` as a literal character class — producing the regex `\s+` (matching whitespace) instead of `.+?` (matching any characters). This causes `parse()` to return `None` for perfectly valid format strings like `"test_{name:s}"`.

Python's `str.format()` treats `:s` as a no-op string type specifier (it's the implicit default). This fix normalizes `type="s"` to `type=""` at the top of the type-handling block, so the existing default pattern logic handles it correctly.

**Fix:** +4 lines in `_handle_field` — clear `type` when it's `"s"` before the elif chain, so the default `.+?` pattern (and width/precision variants) applies.

**RED→GREEN verified:** `parse("test_{name:s}", "test_hello")` → None on baseline, `<Result {'name': 'hello'}>` with fix. 97 tests pass, 1 skip.

This pull request was prepared with the assistance of AI, under my direction and review.