### PR TITLE
Escape literal text in datetime format regexes

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -329,8 +329,17 @@ def get_regex_for_datetime_format(format_):
     Returns:
         str: A regex pattern corresponding to the datetime format string.
     """
-    # Replace all format symbols with their regex patterns.
-    return dt_format_symbols_re.sub(lambda m: dt_format_to_regex[m.group(0)], format_)
+    # Replace all format symbols with their regex patterns, escaping the literal
+    # text between symbols so that regex metacharacters in the format (e.g. ".",
+    # "+", "[", "(") are matched literally rather than interpreted as operators.
+    result = []
+    last = 0
+    for match in dt_format_symbols_re.finditer(format_):
+        result.append(re.escape(format_[last : match.start()]))
+        result.append(dt_format_to_regex[match.group(0)])
+        last = match.end()
+    result.append(re.escape(format_[last:]))
+    return "".join(result)
 
 
 class TooManyFields(ValueError):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -420,6 +420,37 @@ def test_datetime_with_various_subsecond_precision():
     assert r.named["dt"] == datetime(2023, 11, 21, 13, 23, 27, 0)
 
 
+def test_flexible_datetime_with_regex_metacharacters():
+    # Literal text between strftime symbols must be matched literally, not
+    # interpreted as a regex: get_regex_for_datetime_format used to leave the
+    # gaps unescaped, so ".", "+", "[", "(", etc. acted as regex operators.
+    d = date(2023, 3, 7)
+    for sep in [".", "+", "*", "?", "|", "^", "$"]:
+        fmt = "%Y" + sep + "%m" + sep + "%d"
+        text = "2023" + sep + "03" + sep + "07"
+        r = parse.parse("{:" + fmt + "}", text)
+        assert r is not None and r[0] == d, fmt
+
+    # Brackets/parens around a format are literals, not a char-class or group.
+    assert parse.parse("{:[%Y-%m-%d]}", "[2023-03-07]")[0] == d
+    assert parse.parse("{:(%Y-%m-%d)}", "(2023-03-07)")[0] == d
+
+    # A literal "." must not match an arbitrary character, and a non-match must
+    # return None instead of leaking a ValueError out of strptime (the parse()
+    # contract is that the result is either None or a Result).
+    assert parse.parse("{:%Y.%m.%d}", "2023X03X07") is None
+    assert parse.parse("{:%Y.%m.%d}", "2023.03.07")[0] == d
+
+
+def test_flexible_datetime_roundtrips_strftime_output():
+    # parse(fmt, dt.strftime(fmt)) must recover the value even when the format's
+    # literal text contains regex metacharacters.
+    dt = datetime(2023, 3, 7, 9, 5, 42)
+    for fmt in ["%Y-%m-%d %H:%M:%S", "%Y.%m.%d %H:%M:%S", "[%Y-%m-%d] (%H:%M:%S)"]:
+        r = parse.parse("{:" + fmt + "}", dt.strftime(fmt))
+        assert r is not None and r[0] == dt, fmt
+
+
 @pytest.mark.skipif(
     sys.version_info[0] < 3, reason="Python 3+ required for timezone support"
 )


### PR DESCRIPTION
`parse()`'s strftime-style datetime support (`{:%Y-%m-%d}`) builds a regex by replacing each strftime symbol with a sub-pattern (`%Y` → `[0-9]{4}`, …) but leaves the **literal text between symbols unescaped**. Regex metacharacters in the format are therefore interpreted as operators instead of being matched literally, which causes two distinct problems.

**1. `parse()` raises instead of returning `None`**

```python
>>> parse('{:%Y.%m.%d}', '2023X03X07')
ValueError: time data '2023X03X07' does not match format '%Y.%m.%d'
```

The literal `.` compiles to the regex "any character", so the pattern matches `2023X03X07`; `parse` then hands that to `datetime.strptime`, which rejects it, and the `ValueError` propagates out. The README states the result of a `parse()` call is either `None` or a `Result`, so a non-match should return `None`.

**2. Valid strftime output won't round-trip**

```python
>>> parse('{:[%Y-%m-%d]}', '[2023-03-07]')    # None   ('[...]' becomes a char class)
>>> parse('{:(%H:%M)}',    '(09:05)')         # None   ('(...)' becomes a group)
>>> parse('{:%Y-%m-%d+%H}', '2023-03-07+09')  # None   ('+' becomes a quantifier)
```

Each input is the `datetime.strftime` output of the same format string, so `parse(fmt, dt.strftime(fmt))` should recover the value.

**Fix:** in `get_regex_for_datetime_format`, `re.escape` the literal segments between the strftime symbols (the symbol sub-patterns themselves are left untouched).

**Tests:** added round-trip coverage over formats whose literals contain `. + * ? | ^ $ [ ] ( )`, the literal-dot over-match case (must return `None`, not raise), and a literal-dot positive case. The two new tests fail on `master` and pass with the fix; the full suite still passes (99 passed, 1 skipped).

Minor related observation (left out to keep this focused): the `%z` sub-pattern is `[+|-]…`, where the `|` is a literal inside the character class — `[+-]` looks intended. Happy to address in a follow-up.
