### PR TITLE
Honor field width for x/X, o and b integer types (fixes #149)

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -711,15 +711,18 @@ class Parser(object):
             self._group_index += 1
             conv[group] = int_convert(10)
         elif type == "b":
-            s = r"(0[bB])?[01]+"
+            width = r"{1,%s}" % int(format["width"]) if format.get("width") else "+"
+            s = r"(0[bB])?[01]%s" % width
             conv[group] = int_convert(2)
             self._group_index += 1
         elif type == "o":
-            s = r"(0[oO])?[0-7]+"
+            width = r"{1,%s}" % int(format["width"]) if format.get("width") else "+"
+            s = r"(0[oO])?[0-7]%s" % width
             conv[group] = int_convert(8)
             self._group_index += 1
         elif type in ("x", "X"):
-            s = r"(0[xX])?[0-9a-fA-F]+"
+            width = r"{1,%s}" % int(format["width"]) if format.get("width") else "+"
+            s = r"(0[xX])?[0-9a-fA-F]%s" % width
             conv[group] = int_convert(16)
             self._group_index += 1
         elif type == "%":

--- a/tests/test_parsetype.py
+++ b/tests/test_parsetype.py
@@ -201,6 +201,23 @@ def test_width_multi_int():
     assert res.fixed == (44, 4)
 
 
+def test_width_multi_int_bases():
+    # width must be honored for x/X/o/b just like d, otherwise a greedy
+    # match steals digits from the following field (issue #149)
+    assert parse.parse("{:03x}{:03x}", "{:03x}{:03x}".format(1, 2)).fixed == (1, 2)
+    assert parse.parse("{:03X}{:03X}", "{:03X}{:03X}".format(10, 11)).fixed == (10, 11)
+    assert parse.parse("{:03o}{:03o}", "{:03o}{:03o}".format(1, 2)).fixed == (1, 2)
+    assert parse.parse("{:04b}{:04b}", "{:04b}{:04b}".format(1, 2)).fixed == (1, 2)
+    # width is a maximum, not a fixed size (mirrors the {:d} behaviour)
+    assert parse.parse("{:2x}", "a").fixed == (10,)
+    assert parse.parse("{:2x}", "ff").fixed == (255,)
+    assert parse.parse("{:2x}", "fff") is None
+    # without a width the greedy behaviour is unchanged
+    assert parse.parse("{:x}", "ff").fixed == (255,)
+    assert parse.parse("{:o}", "100").fixed == (64,)
+    assert parse.parse("{:b}", "1010").fixed == (10,)
+
+
 def test_width_empty_input():
     res = parse.parse("{:.2}", "")
     assert res is None


### PR DESCRIPTION
## Summary

Fixes #149.

The `d` integer type limits its match to the declared field width, but the `b`, `o`, `x` and `X` types ignored width entirely and matched greedily. When several fixed-width non-decimal integer fields sit next to each other, the first field swallows the following field's digits and the parse is silently wrong.

## Reproduction (on `master`)

```python
>>> from parse import parse
>>> parse("{:03x}{:03x}", "{:03x}{:03x}".format(1, 2))   # input "001002"
<Result (256, 2) {}>          # expected (1, 2)
```

Same class of bug for the other non-decimal integer types:

```python
>>> parse("{:03o}{:03o}", "001002")     # -> (64, 2)   expected (1, 2)
>>> parse("{:04b}{:04b}", "00010010")   # -> (9, 0)    expected (1, 2)
>>> parse("{:03X}{:03X}", "00A00B")     # -> (2560, 11) expected (10, 11)
```

Decimal already behaves correctly because its branch builds the quantifier from `format["width"]`:

```python
>>> parse("{:03d}{:03d}", "001002")     # -> (1, 2)   (correct)
```

## Root cause

In `Parser._handle_field`, the `d` branch honors width with a `{1,N}` quantifier:

```python
elif type == "d":
    if format.get("width"):
        width = r"{1,%s}" % int(format["width"])
    else:
        width = "+"
    s = r"[-+ ]?[0-9{g}]{w}|..."  # width applied
```

but the `b` / `o` / `x`,`X` branches hard-coded a greedy `+` and never looked at `format["width"]`:

```python
elif type in ("x", "X"):
    s = r"(0[xX])?[0-9a-fA-F]+"   # width ignored -> greedy
```

## Fix

Apply the same width handling to the `b`, `o`, `x`/`X` branches: build a `{1,N}` quantifier from `format["width"]`, falling back to the original greedy `+` when no width is given (so prefixed forms such as `0xff` are unaffected). Width stays a **maximum**, not a fixed size, exactly matching the existing `{:d}` semantics that `test_width_multi_int` already pins down.

```diff
 elif type in ("x", "X"):
-    s = r"(0[xX])?[0-9a-fA-F]+"
+    width = r"{1,%s}" % int(format["width"]) if format.get("width") else "+"
+    s = r"(0[xX])?[0-9a-fA-F]%s" % width
```

(+ the analogous two lines for `b` and `o`.)

## After the fix

```python
>>> parse("{:03x}{:03x}", "001002")   # -> (1, 2)
>>> parse("{:03o}{:03o}", "001002")   # -> (1, 2)
>>> parse("{:04b}{:04b}", "00010010") # -> (1, 2)
>>> parse("{:03X}{:03X}", "00A00B")   # -> (10, 11)
# width is a maximum, not a fixed size (unchanged from {:d}):
>>> parse("{:2x}", "a").fixed         # -> (10,)
>>> parse("{:2x}", "ff").fixed        # -> (255,)
>>> parse("{:2x}", "fff")             # -> None
# no-width path unchanged:
>>> parse("{:x}", "0xff").fixed       # -> (255,)
```

## Tests

Added `test_width_multi_int_bases` (mirrors the existing `test_width_multi_int`). Proven to guard the fix — with the source change stashed it fails on `master`:

```
>       assert parse.parse("{:03x}{:03x}", "{:03x}{:03x}".format(1, 2)).fixed == (1, 2)
E       assert (256, 2) == (1, 2)
```

and passes with the fix applied. Full suite: **98 passed, 1 skipped** (was 97 passed + 1 skipped; the +1 is the new test), no regressions. Diff is +23/−3, touches only the four integer-base branches and the new test. Added test file is black-clean.
