### PR TITLE
Fix ValueError on separator-only string for grouped int format

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -745,7 +745,7 @@ class Parser(object):
                 width = r"{1,%s}" % int(format["width"])
             else:
                 width = "+"
-            s = r"[-+ ]?[0-9{g}]{w}|[-+ ]?0[xX][0-9a-fA-F{g}]{w}|[-+ ]?0[bB][01{g}]{w}|[-+ ]?0[oO][0-7{g}]{w}".format(
+            s = r"[-+ ]?(?=[0-9{g}]*[0-9])[0-9{g}]{w}|[-+ ]?0[xX][0-9a-fA-F{g}]{w}|[-+ ]?0[bB][01{g}]{w}|[-+ ]?0[oO][0-7{g}]{w}".format(
                 w=width,
                 g=format.get("grouping", ""),
             )

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -366,6 +366,14 @@ def test_numbers():
     y("a {:_d} b", "a 1_000_000 b", 1000000, str_equals=True)
     y("a {:_d} b", "a -1_000_000 b", -1000000, str_equals=True)
 
+    # A separator-only string must not match a grouped int: the pattern used to
+    # accept it and then int('', base) raised ValueError instead of returning None.
+    n("{:,d}", ",", None)
+    n("{:,d}", ",,", None)
+    n("{:_d}", "_", None)
+    assert parse.parse("{:,d}", ",") is None
+    y("{:,d}", "1,000", 1000)
+
 
 def test_two_datetimes():
     r = parse.parse("a {:ti} {:ti} b", "a 1997-07-16 2012-08-01 b")


### PR DESCRIPTION
parse("{:,d}", ",") raised ValueError instead of returning None. The grouped-int regex first alternative, [-+ ]?[0-9,]+, matched a run of only separators; int_convert then stripped them and called int("", 10).

A lookahead now requires at least one digit in that alternative, so a separator-only string no longer matches. Valid grouped numbers still parse ("1,000" -> 1000, "-1,234" -> -1234), and plain "{:d}"/hex/bin/oct are unaffected.

Repro: parse.parse("{:,d}", ",")