### PR TITLE
Fix ValueError on Unicode digits in "n" number format

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -707,7 +707,8 @@ class Parser(object):
             self._group_index += regex_group_count
             conv[group] = convert_first(type_converter)
         elif type == "n":
-            s = r"\d{1,3}([,.]\d{3})*"
+            # ASCII only: int_convert strips to [0-9], so a Unicode-digit match reduces to "".
+            s = r"[0-9]{1,3}([,.][0-9]{3})*"
             self._group_index += 1
             conv[group] = int_convert(10)
         elif type == "b":

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -270,6 +270,12 @@ def test_numbers():
     n("a {:n} b", "a 100,00 b", None)
     y("a {:n} b", "a 100.000 b", 100000)
     y("a {:n} b", "a 1.000.000 b", 1000000)
+    # Unicode digits must not match: int_convert only handles ASCII, so a
+    # non-ASCII digit used to reduce to "" and raise ValueError instead of None.
+    n("{:n}", "٠", None)
+    n("{:n}", "۰", None)
+    assert parse.parse("{:n}", "٠") is None
+    assert list(parse.findall("{:n}", "٠")) == []
 
     y("a {:f} b", "a 12.0 b", 12.0)
     y("a {:f} b", "a -12.1 b", -12.1)


### PR DESCRIPTION
parse.parse("{:n}", "٠") (Arabic-Indic zero, U+0660) raised ValueError instead of returning None. The "{:n}" pattern used \d, which matches non-ASCII decimal digits, but int_convert strips the match to ASCII with re.sub("[^0-9]", ...) and then calls int("", 10).

Using an explicit [0-9] class makes the pattern match only the digits the converter can handle, matching the other integer types (d, b, o, x). Valid grouped numbers still parse.

Repro: parse.parse("{:n}", "٠")