### PR TITLE
fix: return None when date type conversion fails

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -967,19 +967,18 @@ class ResultIterator(object):
         return self
 
     def __next__(self):
-        m = self.parser._search_re.search(self.string, self.pos, self.endpos)
-        if m is None:
-            raise StopIteration()
-        self.pos = m.end()
+        while True:
+            m = self.parser._search_re.search(self.string, self.pos, self.endpos)
+            if m is None:
+                raise StopIteration()
+            self.pos = m.end()
 
-        if self.evaluate_result:
+            if not self.evaluate_result:
+                return Match(self.parser, m)
             try:
                 return self.parser.evaluate_result(m)
             except ConversionFailure:
-                # Skip this match and keep searching.
-                return next(self)
-        else:
-            return Match(self.parser, m)
+                continue
 
     # pre-py3k compat
     next = __next__

--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -17,6 +17,10 @@ __all__ = ["parse", "search", "findall", "with_pattern"]
 log = logging.getLogger(__name__)
 
 
+class ConversionFailure(Exception):
+    """Internal: a type converter rejected a string that matched its regex."""
+
+
 def with_pattern(pattern, regex_group_count=None):
     r"""Attach a regular expression pattern matcher to a custom type converter
     function.
@@ -190,6 +194,30 @@ def date_convert(
     """Convert the incoming string containing some date / time info into a
     datetime instance.
     """
+    try:
+        return _date_convert(
+            string, match, ymd, mdy, dmy, d_m_y, hms, am, tz, mm, dd
+        )
+    except (ValueError, OverflowError) as e:
+        raise ConversionFailure from e
+
+
+def _date_convert(
+    string,
+    match,
+    ymd=None,
+    mdy=None,
+    dmy=None,
+    d_m_y=None,
+    hms=None,
+    am=None,
+    tz=None,
+    mm=None,
+    dd=None,
+):
+    """Convert the incoming string containing some date / time info into a
+    datetime instance.
+    """
     groups = match.groups()
     time_only = False
     if mm and dd:
@@ -277,18 +305,22 @@ def strf_date_convert(x, _, type):
     is_date = any("%" + x in type for x in "aAwdbBmyYjUW")
     is_time = any("%" + x in type for x in "HIpMSfz")
 
-    dt = datetime.strptime(x, type)
-    if "%y" not in type and "%Y" not in type:  # year not specified
-        dt = dt.replace(year=datetime.today().year)
+    if not is_date and not is_time:
+        raise ValueError("Datetime not a date nor a time?")
+
+    try:
+        dt = datetime.strptime(x, type)
+        if "%y" not in type and "%Y" not in type:  # year not specified
+            dt = dt.replace(year=datetime.today().year)
+    except ValueError as e:
+        raise ConversionFailure from e
 
     if is_date and is_time:
         return dt
     elif is_date:
         return dt.date()
-    elif is_time:
-        return dt.time()
     else:
-        raise ValueError("Datetime not a date nor a time?")
+        return dt.time()
 
 
 # ref: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
@@ -504,7 +536,10 @@ class Parser(object):
             return None
 
         if evaluate_result:
-            return self.evaluate_result(m)
+            try:
+                return self.evaluate_result(m)
+            except ConversionFailure:
+                return None
         else:
             return Match(self, m)
 
@@ -527,7 +562,10 @@ class Parser(object):
             return None
 
         if evaluate_result:
-            return self.evaluate_result(m)
+            try:
+                return self.evaluate_result(m)
+            except ConversionFailure:
+                return None
         else:
             return Match(self, m)
 
@@ -906,7 +944,10 @@ class Match(object):
 
     def evaluate_result(self):
         """Generate results for this Match"""
-        return self.parser.evaluate_result(self.match)
+        try:
+            return self.parser.evaluate_result(self.match)
+        except ConversionFailure:
+            return None
 
 
 class ResultIterator(object):
@@ -932,7 +973,11 @@ class ResultIterator(object):
         self.pos = m.end()
 
         if self.evaluate_result:
-            return self.parser.evaluate_result(m)
+            try:
+                return self.parser.evaluate_result(m)
+            except ConversionFailure:
+                # Skip this match and keep searching.
+                return next(self)
         else:
             return Match(self.parser, m)
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -789,13 +789,17 @@ def test_strftime_strptime_roundtrip():
 def test_invalid_date_conversion_returns_none():
     # Regex can match calendar-invalid values; conversion must not raise.
     assert parse.parse("{:%Y-%m-%d}", "2020-13-01") is None
+    assert parse.parse("{:%Y-%m-%d}", "2020-02-30") is None
     assert parse.parse("{:%H:%M}", "25:61") is None
     assert parse.parse("{:ti}", "2020-13-01T00:00:00") is None
+    assert parse.parse("{:ti}", "2020-02-30") is None
+    assert parse.parse("{:tt}", "25:00:00") is None
     assert parse.parse("{:tg}", "40/13/2020") is None
     assert parse.parse("{:ta}", "13/40/2020") is None
     # Valid values still convert.
     assert parse.parse("{:%Y-%m-%d}", "2020-01-15")[0] == datetime(2020, 1, 15).date()
     assert parse.parse("{:ti}", "2020-01-01T00:00:00")[0] == datetime(2020, 1, 1, 0, 0, 0)
+    assert parse.parse("{:tt}", "12:00:00")[0].hour == 12
     results = list(parse.findall("{:%Y-%m-%d}", "2020-13-01 2020-01-15"))
     assert len(results) == 1
     assert results[0][0] == datetime(2020, 1, 15).date()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -786,6 +786,18 @@ def test_strftime_strptime_roundtrip():
     assert res == dt
 
 
+def test_invalid_date_conversion_returns_none():
+    # Regex can match calendar-invalid values; conversion must not raise.
+    assert parse.parse("{:%Y-%m-%d}", "2020-13-01") is None
+    assert parse.parse("{:%H:%M}", "25:61") is None
+    assert parse.parse("{:ti}", "2020-13-01T00:00:00") is None
+    assert parse.parse("{:tg}", "40/13/2020") is None
+    assert parse.parse("{:ta}", "13/40/2020") is None
+    # Valid values still convert.
+    assert parse.parse("{:%Y-%m-%d}", "2020-01-15")[0] == datetime(2020, 1, 15).date()
+    assert parse.parse("{:ti}", "2020-01-01T00:00:00")[0] == datetime(2020, 1, 1, 0, 0, 0)
+
+
 def test_parser_format():
     parser = parse.compile("hello {}")
     assert parser.format.format("world") == "hello world"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -796,6 +796,9 @@ def test_invalid_date_conversion_returns_none():
     # Valid values still convert.
     assert parse.parse("{:%Y-%m-%d}", "2020-01-15")[0] == datetime(2020, 1, 15).date()
     assert parse.parse("{:ti}", "2020-01-01T00:00:00")[0] == datetime(2020, 1, 1, 0, 0, 0)
+    results = list(parse.findall("{:%Y-%m-%d}", "2020-13-01 2020-01-15"))
+    assert len(results) == 1
+    assert results[0][0] == datetime(2020, 1, 15).date()
 
 
 def test_parser_format():


### PR DESCRIPTION
parse.date_convert/strf_date_convert hits ValueError when invalid calendar date matching type regex e.g. 2020-13-01 / {:ti} month 13. This PR fixes the regression with a focused test covering the case.
