### PR TITLE
Fix integer precision parsing for adjacent fields

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -697,6 +697,17 @@ class Parser(object):
         # figure type conversions, if any
         type = format["type"]
         is_numeric = type and type in "n%fegdobxEGX"
+        precision = format.get("precision")
+
+        def repeated_digits(default="+"):
+            if precision:
+                minimum = int(format.get("width") or 1)
+                maximum = int(precision)
+                if minimum > maximum:
+                    minimum = maximum
+                return r"{%s,%s}" % (minimum, maximum)
+            return default
+
         conv = self._type_conversions
         if type in self._extra_types:
             type_converter = self._extra_types[type]
@@ -711,15 +722,15 @@ class Parser(object):
             self._group_index += 1
             conv[group] = int_convert(10)
         elif type == "b":
-            s = r"(0[bB])?[01]+"
+            s = r"(0[bB])?[01]%s" % repeated_digits()
             conv[group] = int_convert(2)
             self._group_index += 1
         elif type == "o":
-            s = r"(0[oO])?[0-7]+"
+            s = r"(0[oO])?[0-7]%s" % repeated_digits()
             conv[group] = int_convert(8)
             self._group_index += 1
         elif type in ("x", "X"):
-            s = r"(0[xX])?[0-9a-fA-F]+"
+            s = r"(0[xX])?[0-9a-fA-F]%s" % repeated_digits()
             conv[group] = int_convert(16)
             self._group_index += 1
         elif type == "%":
@@ -741,7 +752,9 @@ class Parser(object):
             self._group_index += 2
             conv[group] = convert_first(float)
         elif type == "d":
-            if format.get("width"):
+            if precision:
+                width = repeated_digits()
+            elif format.get("width"):
                 width = r"{1,%s}" % int(format["width"])
             else:
                 width = "+"

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -119,3 +119,13 @@ def test_microsecond_precision_issue162():
     # more than 6 fractional digits should be truncated
     r = parse.parse("{:ti}", "2023-10-14T15:09:08.1234567Z")
     assert r[0].microsecond == 123456
+
+
+def test_integer_precision_limits_digits_issue107():
+    r = parse.parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFFFFF")
+    assert r.fixed == (255, 255, 255)
+
+    assert parse.parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFFF") is None
+    assert parse.parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFF") is None
+    assert parse.parse("{:2.2d}{:2.2d}{:2.2d}", "9999") is None
+    assert parse.parse("{:2.2d}{:2.2d}{:2.2d}", "999") is None


### PR DESCRIPTION
Fixes #107

## Reproduction

On `master`, adjacent integer fields with both width and precision can consume the wrong number of digits:

```py
>>> parse.parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFFFFF")
<Result (65535, 15, 15) {}>
>>> parse.parse("{:2.2d}{:2.2d}{:2.2d}", "9999")
<Result (99, 9, 9) {}>
```

The first field ignores the `.2` precision and greedily consumes digits that belong to later fields.

## Root cause

`extract_format()` records precision for numeric formats, but `_handle_field()` ignored it for integer formats (`d`, `b`, `o`, `x`, `X`). Hex/binary/octal always used `+`, and decimal only used width as a maximum digit count.

## Fix

Apply the parsed precision as a maximum digit count for integer regexes, using the width as the minimum when present. This makes `{:2.2x}` and `{:2.2d}` match exactly two digits and prevents adjacent fields from stealing each other's input.

## Compatibility notes

This only tightens integer matching when a precision is explicitly present in the format specifier. Existing integer specs without precision keep their previous regex behavior.

## Validation

- New regression test fails without the fix: `tests\test_bugs.py::test_integer_precision_limits_digits_issue107` fails with `(65535, 15, 15) != (255, 255, 255)`.
- New regression test passes with the fix: `1 passed`.
- Full suite: `python -m pytest` -> `100 passed, 1 skipped`.
- CI type checks: `python -m mypy --check-untyped-defs --disallow-any-generics parse`, `python -m mypy.stubtest parse`, and `python -m mypy tests\check_typing.py` all passed.
- No ruff configuration was found in the repository.