### PR TITLE
Fix handling of the fill character in format specs

### DIFF
--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -351,13 +351,16 @@ ALLOWED_TYPES = set(list("nboxX%fFeEgGwWdDsSl") + ["t" + c for c in "ieahgcts"])
 def extract_format(format, extra_types):
     """Pull apart the format [[fill]align][sign][0][width][grouping][.precision][type]"""
     fill = align = None
-    if format[0] in "<>=^":
-        align = format[0]
-        format = format[1:]
-    elif len(format) > 1 and format[1] in "<>=^":
+    # Note the fill character is checked first, matching the behaviour of
+    # format() itself: a fill character may itself be an alignment character,
+    # as in "{:^^10}" (center-aligned, padded with "^").
+    if len(format) > 1 and format[1] in "<>=^":
         fill = format[0]
         align = format[1]
         format = format[2:]
+    elif format[0] in "<>=^":
+        align = format[0]
+        format = format[1:]
 
     if format.startswith(("+", "-", " ")):
         format = format[1:]
@@ -821,6 +824,12 @@ class Parser(object):
         align = format["align"]
         fill = format["fill"]
 
+        # The fill character is interpolated into the regular expression
+        # below, so escape it if it has a special meaning there. This has to
+        # happen before the "=" alignment uses it.
+        if fill:
+            fill = re.escape(fill)
+
         # handle some numeric-specific things like fill and sign
         if is_numeric:
             # prefix with something (align "=" trumps zero)
@@ -850,9 +859,6 @@ class Parser(object):
             # padding
             if not align:
                 align = ">"
-
-        if fill in r".\+?*[](){}^$":
-            fill = "\\" + fill
 
         # align "=" has been handled
         if align == "<":

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -119,3 +119,32 @@ def test_microsecond_precision_issue162():
     # more than 6 fractional digits should be truncated
     r = parse.parse("{:ti}", "2023-10-14T15:09:08.1234567Z")
     assert r[0].microsecond == 123456
+
+
+def test_regex_special_fill_character():
+    # the fill character is interpolated into the generated regular
+    # expression, so one that is a regex metacharacter has to be escaped;
+    # previously these raised NotImplementedError or failed to match
+    for fill in "*+?.()[]{}|^$\\/!#~":
+        for align in "<>=^":
+            spec = fill + align + "6d"
+            text = format(42, spec)
+            r = parse.parse("{:" + spec + "}", text)
+            assert r is not None, "no match for {!r} against {!r}".format(spec, text)
+            assert r[0] == 42, spec
+
+
+def test_fill_character_that_is_an_alignment_character():
+    # a fill character may itself be an alignment character, as in "{:^^6d}"
+    # (centered, padded with "^"). The leading "^" used to be read as the
+    # alignment, leaving "^6d" to be rejected as an unknown format spec.
+    for fill in "<>=^":
+        for align in "<>=^":
+            spec = fill + align + "6d"
+            text = format(42, spec)
+            r = parse.parse("{:" + spec + "}", text)
+            assert r is not None, "no match for {!r} against {!r}".format(spec, text)
+            assert r[0] == 42, spec
+
+    # the same applies to non-numeric fields
+    assert parse.parse("{:^^10}", format("spam", "^^10")) is not None

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -58,6 +58,10 @@ def test_format_variety():
     _("^", {"align": "^"})
     _(".^", {"align": "^", "fill": "."})
     _("x=d", {"type": "d", "align": "=", "fill": "x"})
+    # a fill character may itself be an alignment character
+    _("^^d", {"type": "d", "align": "^", "fill": "^"})
+    _("<<d", {"type": "d", "align": "<", "fill": "<"})
+    _("==d", {"type": "d", "align": "=", "fill": "="})
     _("d", {"type": "d"})
     _("ti", {"type": "ti"})
     _("spam", {"type": "spam"})


### PR DESCRIPTION
The fill character of a format spec is interpolated into the regular expression that is built for the field, but it is not consistently escaped, so a fill character that means something in a regex produces a broken pattern.

### Reproduction

```pycon
>>> import parse
>>> parse.parse("{:*=6d}", format(42, "*=6d"))     # '****42'
NotImplementedError: Group names (e.g. (?P<name>) can cause failure, as they are not escaped properly: ...
>>> parse.parse("{:|<6d}", format(42, "|<6d}"[:-1]))   # '42||||'
NotImplementedError: Group names (e.g. (?P<name>) can cause failure, as they are not escaped properly: ...
>>> parse.parse("{:^^6d}", format(42, "^^6d"))     # '^^42^^'
ValueError: format spec '^6d' not recognised
```

All three are specs that `format()` accepts, so `parse()` should round-trip the value it produced.

### Cause

Two separate things, both about the fill character:

1. In `Parser._handle_field()` the fill was escaped at the end of the method, but the `"="` alignment branch had already used the raw character several lines earlier, so `"{:*=6d}"` put a bare `*` into the pattern. The escape set itself (`r".\+?*[](){}^$"`) also omitted `|`, which is why `"{:|<6d}"` failed for every alignment.

2. `extract_format()` tested for an alignment character at position 0 before testing for a `[fill]align` pair at position 1. A fill character that is itself an alignment character was therefore read as the alignment, leaving the remainder of the spec to be rejected. CPython's own format-spec parser checks the pair first.

### Change

Escape the fill with `re.escape()` before anything uses it, and drop the late hand-written escape (`re.escape` also covers the characters it missed). In `extract_format()`, check for the `[fill]align` pair before a bare alignment character.

### Verification

The existing suite passes unchanged. The three added tests fail on `main` and pass with the change.

I also swept every `format()` spec built from fill x align x width x precision x type over a range of values, and compared what `parse()` returns against the value `format()` started from — 48,480 round-trips:

| | before | after |
|---|---|---|
| correct | 33,485 | 45,636 |
| raises | 13,735 | 2,020 |
| no match | 1,033 | 597 |
| wrong value | 227 | 227 |

12,155 cases go from broken to correct and none regress, with one exception worth calling out: four cases of the form `"{:.=1d}"` (fill `.`, `=` alignment, width 1) previously returned a value and now do not match. Those only worked because the unescaped `.` acted as a wildcard that swallowed the extra digits — `parse("{:1d}", "42")` already returned no match before this change, so what is left is the existing narrow-width behaviour rather than something new.

Not addressed here, since they look like separate concerns: `"="` alignment keeps the padding inside the captured group (harmless for the integer types because `int_convert` strips it, but the float types then fail to convert), and `"="` alignment assumes a `0` fill where `format()` defaults to a space.
